### PR TITLE
Fix NullReferenceException under some cases

### DIFF
--- a/Dalamud.Tomestone/ContextMenu.cs
+++ b/Dalamud.Tomestone/ContextMenu.cs
@@ -78,7 +78,7 @@ namespace Dalamud.Tomestone
                 return;
             }
 
-            Utils.OpenTomestoneLink(world.Name.ExtractText(), playerName);
+            Utils.OpenTomestoneLink(world!.Name.ExtractText(), playerName);
         }
     }
 }

--- a/Dalamud.Tomestone/Utils/DalamudUtils.cs
+++ b/Dalamud.Tomestone/Utils/DalamudUtils.cs
@@ -15,9 +15,9 @@ namespace Dalamud.Tomestone
             return IsWorldValid(GetWorld(worldId));
         }
 
-        public static bool IsWorldValid(World world)
+        public static bool IsWorldValid(World? world)
         {
-            if (world.Name.Data.IsEmpty || GetRegionCode(world) == string.Empty)
+            if (world == null || world?.Name.Data.IsEmpty || GetRegionCode(world) == string.Empty)
             {
                 return false;
             }
@@ -25,16 +25,16 @@ namespace Dalamud.Tomestone
             return char.IsUpper((char)world.Name.Data.Span[0]);
         }
 
-        public static World GetWorld(uint worldId)
+        public static World? GetWorld(uint worldId)
         {
             var worldSheet = Service.DataManager.GetExcelSheet<World>()!;
-            var world = worldSheet.FirstOrDefault(x => x.RowId == worldId);
+            var world = worldSheet.FirstOrNull(x => x.RowId == worldId);
             return world;
         }
 
-        public static string GetRegionCode(World world)
+        public static string GetRegionCode(World? world)
         {
-            return world.DataCenter.ValueNullable?.Region switch
+            return world?.DataCenter.ValueNullable?.Region switch
             {
                 1 => "JP",
                 2 => "NA",


### PR DESCRIPTION
```
11:03:16.275 | ERR | Exception during raise of "Void OnMenuOpenedForward(Dalamud.Game.Gui.ContextMenu.IMenuOpenedArgs)"
	System.NullReferenceException: Object reference not set to an instance of an object.
	   at Dalamud.Tomestone.DalamudUtils.IsWorldValid(World world) in /_/Dalamud.Tomestone/Utils/DalamudUtils.cs:line 20
	   at Dalamud.Tomestone.ContextMenu.IsMenuValid(IMenuArgs menuOpenedArgs) in /_/Dalamud.Tomestone/ContextMenu.cs:line 38
	   at Dalamud.Tomestone.ContextMenu.OnOpenContextMenu(IMenuOpenedArgs menuOpenedArgs) in /_/Dalamud.Tomestone/ContextMenu.cs:line 50
	   at Dalamud.Utility.EventHandlerExtensions.InvokeSafely(OnMenuOpenedDelegate openedDelegate, MenuOpenedArgs argument) in /_/Dalamud/Utility/EventHandlerExtensions.cs:line 146
```